### PR TITLE
Set feeder to position mode when stopped

### DIFF
--- a/2020-InfiniteRecharge/src/main/java/frc/robot/subsystems/PowerCell.java
+++ b/2020-InfiniteRecharge/src/main/java/frc/robot/subsystems/PowerCell.java
@@ -179,7 +179,7 @@ public class PowerCell implements Loggable{
         storageMotorH.configPeakOutputReverse(-1, TIMEOUT);
         storageMotorH.enableCurrentLimit(true);
 		storageMotorH.configPeakCurrentLimit(5,TIMEOUT);
-		storageMotorH.configContinuousCurrentLimit(2, TIMEOUT);
+		storageMotorH.configContinuousCurrentLimit(5, TIMEOUT);
 		storageMotorH.configPeakCurrentDuration(1800,TIMEOUT);
         storageMotorH.setNeutralMode(NeutralMode.Brake);
 
@@ -196,7 +196,7 @@ public class PowerCell implements Loggable{
         storageMotorL.configPeakOutputReverse(-1, TIMEOUT);
         storageMotorL.enableCurrentLimit(true);
 		storageMotorL.configPeakCurrentLimit(5, TIMEOUT);
-		storageMotorL.configContinuousCurrentLimit(2, TIMEOUT);
+		storageMotorL.configContinuousCurrentLimit(5, TIMEOUT);
 		storageMotorL.configPeakCurrentDuration(1800,TIMEOUT);
         storageMotorL.setNeutralMode(NeutralMode.Brake);
     }
@@ -215,6 +215,8 @@ public class PowerCell implements Loggable{
         shooter.set(TalonFXControlMode.PercentOutput, 0);
     }
     public void feeder(){
+        
+        
         if(oi.pilot.getRawButton(1)){
             feederMotor.set(ControlMode.PercentOutput, feederRpms);// Will need to be velocity
         }

--- a/2020-InfiniteRecharge/src/main/java/frc/robot/subsystems/PowerCell.java
+++ b/2020-InfiniteRecharge/src/main/java/frc/robot/subsystems/PowerCell.java
@@ -38,7 +38,7 @@ public class PowerCell implements Loggable{
     private double storage_kI = 0;
     private double storage_kF = 0;
     @Log
-    private double feederP_kP = 0;//5e-5 
+    private double feederP_kP = .0001;//5e-5 
     private double feederP_kD = 0;
     @Log
     private double feederP_kI = 0;

--- a/2020-InfiniteRecharge/src/main/java/frc/robot/subsystems/PowerCell.java
+++ b/2020-InfiniteRecharge/src/main/java/frc/robot/subsystems/PowerCell.java
@@ -177,8 +177,8 @@ public class PowerCell implements Loggable{
         storageMotorH.configPeakOutputForward(+1, TIMEOUT);
         storageMotorH.configPeakOutputReverse(-1, TIMEOUT);
         storageMotorH.enableCurrentLimit(true);
-		storageMotorH.configPeakCurrentLimit(5,TIMEOUT);
-		storageMotorH.configContinuousCurrentLimit(5, TIMEOUT);
+		storageMotorH.configPeakCurrentLimit(10,TIMEOUT);
+		storageMotorH.configContinuousCurrentLimit(10, TIMEOUT);
 		storageMotorH.configPeakCurrentDuration(1800,TIMEOUT);
         storageMotorH.setNeutralMode(NeutralMode.Brake);
 
@@ -194,10 +194,11 @@ public class PowerCell implements Loggable{
         storageMotorL.configPeakOutputForward(+1, TIMEOUT);
         storageMotorL.configPeakOutputReverse(-1, TIMEOUT);
         storageMotorL.enableCurrentLimit(true);
-		storageMotorL.configPeakCurrentLimit(5, TIMEOUT);
-		storageMotorL.configContinuousCurrentLimit(5, TIMEOUT);
+		storageMotorL.configPeakCurrentLimit(10, TIMEOUT);
+		storageMotorL.configContinuousCurrentLimit(10, TIMEOUT);
 		storageMotorL.configPeakCurrentDuration(1800,TIMEOUT);
         storageMotorL.setNeutralMode(NeutralMode.Brake);
+        stopfeeder();
     }
     public void stopfeeder(){
         feederPosition = feederMotor.getSelectedSensorPosition();
@@ -219,7 +220,7 @@ public class PowerCell implements Loggable{
         {
            if(!feederButton)
            {
-                feederMotor.set(ControlMode.Velocity, feederRpms);
+                feederMotor.set(ControlMode.PercentOutput, feederRpms);
                 feederButton = true;
            }
         }

--- a/2020-InfiniteRecharge/src/main/java/frc/robot/subsystems/PowerCell.java
+++ b/2020-InfiniteRecharge/src/main/java/frc/robot/subsystems/PowerCell.java
@@ -38,13 +38,11 @@ public class PowerCell implements Loggable{
     private double storage_kI = 0;
     private double storage_kF = 0;
     @Log
-    private double feeder_kP = 0;//5e-5 
-    private double feeder_kD = 0;
+    private double feederP_kP = 0;//5e-5 
+    private double feederP_kD = 0;
     @Log
-    private double feederV_kI = 0;//1e-6
-    private double feederV_kF = 0;
-    private double feederPosition_kI = 0;
-    private double feederPosition_kF = 0;
+    private double feederP_kI = 0;
+    private double feederP_kF = 0;
     private boolean feederButton = false;
     
     //motors 
@@ -92,7 +90,7 @@ public class PowerCell implements Loggable{
         feederMotor.config_kD(0, kD);
         feederMotor.config_kI(0, kI);
         feederRpms = Rpms;
-        feeder_kP = kP;
+        feederP_kP = kP;
     }
     
     @Config
@@ -152,10 +150,10 @@ public class PowerCell implements Loggable{
         feederMotor.set(ControlMode.PercentOutput, 0);	
         feederMotor.configClosedloopRamp(cLR, TIMEOUT);
         feederMotor.configSelectedFeedbackSensor(FeedbackDevice.QuadEncoder);
-        feederMotor.config_kF(0, feederV_kF);
-        feederMotor.config_kP(0, feeder_kP);
-        feederMotor.config_kD(0, feeder_kD);
-        feederMotor.config_kI(0, feederV_kI);
+        feederMotor.config_kF(0, feederP_kF);
+        feederMotor.config_kP(0, feederP_kP);
+        feederMotor.config_kD(0, feederP_kD);
+        feederMotor.config_kI(0, feederP_kI);
         feederMotor.configNominalOutputForward(0, TIMEOUT);
         feederMotor.configNominalOutputReverse(0, TIMEOUT);
         feederMotor.configPeakOutputForward(+1, TIMEOUT);
@@ -202,7 +200,7 @@ public class PowerCell implements Loggable{
         storageMotorL.setNeutralMode(NeutralMode.Brake);
     }
     public void stopfeeder(){
-        feederPosition = feederMotor.getActiveTrajectoryPosition();
+        feederPosition = feederMotor.getSelectedSensorPosition();
         feederMotor.set(ControlMode.Position, feederPosition);
     }
     public void stopStorage(){
@@ -217,21 +215,22 @@ public class PowerCell implements Loggable{
         shooter.set(TalonFXControlMode.PercentOutput, 0);
     }
     public void feeder(){   
-        if(oi.pilot.getRawButton(1) == false && feederButton == true){
-            feederMotor.set(ControlMode.Position, feederRpms);// Will need to be velocity
+        if(oi.pilot.getRawButton(1))
+        {
+           if(!feederButton)
+           {
+                feederMotor.set(ControlMode.Velocity, feederRpms);
+                feederButton = true;
+           }
         }
-        else{
-            stopfeeder();
+        else
+        {
+            if(feederButton)
+            {
+                stopfeeder();
+                feederButton = false;
+            }
         }
-        
-        if(oi.pilot.getRawButton(1)){
-            feederMotor.set(ControlMode.Velocity, feederRpms);// Will need to be velocity
-            feederButton = true;
-        }
-        else{
-            feederButton = false;
-        }
-        
     }
     public void storage(){
         if(oi.copilot.getRawButton(3)){


### PR DESCRIPTION
This PR sets the feeder to position mode when stopped, so that it actively holds position. This will prevent power cells from being pushed through to the shooter too soon. 